### PR TITLE
Use Request instead of BaseRequest

### DIFF
--- a/BMSCore.xcodeproj/project.pbxproj
+++ b/BMSCore.xcodeproj/project.pbxproj
@@ -25,7 +25,7 @@
 		92018A5A1C45AACC0031C893 /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92018A4A1C45AA890031C893 /* Request.swift */; };
 		92018A5D1C45AAD60031C893 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92018A171C45A7720031C893 /* Error.swift */; };
 		92018A8D1C45AC380031C893 /* BMSClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92018A771C45AC380031C893 /* BMSClientTests.swift */; };
-		92018A8F1C45AC380031C893 /* BaseRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92018A791C45AC380031C893 /* BaseRequestTests.swift */; };
+		92018A8F1C45AC380031C893 /* RequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92018A791C45AC380031C893 /* RequestTests.swift */; };
 		92018A921C45AC380031C893 /* ResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92018A7D1C45AC380031C893 /* ResponseTests.swift */; };
 		920B505F1E1DAC2900FB546F /* NetworkDetectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 920B505E1E1DAC2900FB546F /* NetworkDetectionTests.swift */; };
 		921D0CD61DF7823800EB6F7D /* BMSClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921D0CD51DF7823800EB6F7D /* BMSClient.swift */; };
@@ -183,7 +183,7 @@
 		92018A4B1C45AA890031C893 /* BaseRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseRequest.swift; sourceTree = "<group>"; };
 		92018A4C1C45AA890031C893 /* Response.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Response.swift; sourceTree = "<group>"; };
 		92018A771C45AC380031C893 /* BMSClientTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BMSClientTests.swift; sourceTree = "<group>"; };
-		92018A791C45AC380031C893 /* BaseRequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseRequestTests.swift; sourceTree = "<group>"; };
+		92018A791C45AC380031C893 /* RequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestTests.swift; sourceTree = "<group>"; };
 		92018A7B1C45AC380031C893 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		92018A7D1C45AC380031C893 /* ResponseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResponseTests.swift; sourceTree = "<group>"; };
 		920B505E1E1DAC2900FB546F /* NetworkDetectionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkDetectionTests.swift; sourceTree = "<group>"; };
@@ -391,7 +391,7 @@
 			isa = PBXGroup;
 			children = (
 				92018A771C45AC380031C893 /* BMSClientTests.swift */,
-				92018A791C45AC380031C893 /* BaseRequestTests.swift */,
+				92018A791C45AC380031C893 /* RequestTests.swift */,
 				92018A7D1C45AC380031C893 /* ResponseTests.swift */,
 				92A60C091D831F6D005E0969 /* BMSUrlSessionTests.swift */,
 				92A60C0B1D831F8E005E0969 /* BMSUrlSessionDelegateTests.swift */,
@@ -1086,7 +1086,7 @@
 				92B019071E26E3D4002A05CB /* BMSURLSessionUtilityTests.swift in Sources */,
 				92018A8D1C45AC380031C893 /* BMSClientTests.swift in Sources */,
 				92A60C0A1D831F6D005E0969 /* BMSUrlSessionTests.swift in Sources */,
-				92018A8F1C45AC380031C893 /* BaseRequestTests.swift in Sources */,
+				92018A8F1C45AC380031C893 /* RequestTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Source/Network Requests/BMSURLSessionUtility.swift
+++ b/Source/Network Requests/BMSURLSessionUtility.swift
@@ -41,7 +41,7 @@ internal struct BMSURLSessionUtility {
             
             // Analytics
             bmsRequest.setValue(UUID().uuidString, forHTTPHeaderField: "x-wl-analytics-tracking-id")
-            if let requestMetadata = BaseRequest.requestAnalyticsData {
+            if let requestMetadata = Request.requestAnalyticsData {
                 bmsRequest.setValue(requestMetadata, forHTTPHeaderField: "x-mfp-analytics-metadata")
             }
         }

--- a/Tests/Unit Tests/BMSURLSessionUtilityTests.swift
+++ b/Tests/Unit Tests/BMSURLSessionUtilityTests.swift
@@ -53,8 +53,8 @@ class BMSURLSessionUtilityTests: XCTestCase {
         
         BMSClient.sharedInstance.authorizationManager = TestAuthorizationManager()
         
-        XCTAssertNil(BaseRequest.requestAnalyticsData)
-        BaseRequest.requestAnalyticsData = "testData"
+        XCTAssertNil(Request.requestAnalyticsData)
+        Request.requestAnalyticsData = "testData"
         
         let originalRequest = URLRequest(url: testUrl)
         let preparedRequest = BMSURLSessionUtility.addBMSHeaders(to: originalRequest, onlyIf: true)
@@ -63,7 +63,7 @@ class BMSURLSessionUtilityTests: XCTestCase {
         XCTAssertEqual(preparedRequest.allHTTPHeaderFields?["x-mfp-analytics-metadata"], "testData")
         XCTAssertNotNil(preparedRequest.allHTTPHeaderFields?["x-wl-analytics-tracking-id"])
         
-        BaseRequest.requestAnalyticsData = nil
+        Request.requestAnalyticsData = nil
         
         BMSClient.sharedInstance.authorizationManager = BaseAuthorizationManager()
     }

--- a/Tests/Unit Tests/RequestTests.swift
+++ b/Tests/Unit Tests/RequestTests.swift
@@ -22,19 +22,19 @@ import XCTest
     
     
 
-class BaseRequestTests: XCTestCase {
+class RequestTests: XCTestCase {
     
     
     // MARK: init
     
     func testInitWithAllParameters() {
         
-        let request = BaseRequest(url: "http://example.com", method: HttpMethod.GET, headers:[BaseRequest.contentType: "text/plain"], queryParameters: ["someKey": "someValue"], timeout: 10.0, autoRetries: 4)
+        let request = Request(url: "http://example.com", method: HttpMethod.GET, headers:[Request.contentType: "text/plain"], queryParameters: ["someKey": "someValue"], timeout: 10.0, autoRetries: 4)
         
         XCTAssertEqual(request.resourceUrl, "http://example.com")
         XCTAssertEqual(request.httpMethod.rawValue, "GET")
         XCTAssertEqual(request.timeout, 10.0)
-        XCTAssertEqual(request.headers, [BaseRequest.contentType: "text/plain"])
+        XCTAssertEqual(request.headers, [Request.contentType: "text/plain"])
         XCTAssertEqual(request.queryParameters!, ["someKey": "someValue"])
         XCTAssertEqual(request.urlSession.numberOfRetries, 4)
         XCTAssertNotNil(request.networkRequest)
@@ -44,14 +44,14 @@ class BaseRequestTests: XCTestCase {
     
         BMSClient.sharedInstance.initialize(bluemixAppRoute: "https://mybluemixapp.net", bluemixAppGUID: "1234", bluemixRegion: BMSClient.Region.usSouth)
         
-        let request = BaseRequest(url: "/path/to/resource", headers: nil, queryParameters: nil)
+        let request = Request(url: "/path/to/resource", headers: nil, queryParameters: nil)
         
         XCTAssertEqual(request.resourceUrl, "https://mybluemixapp.net/path/to/resource")
     }
     
     func testInitWithDefaultParameters() {
         
-        let request = BaseRequest(url: "http://example.com", headers: nil, queryParameters: nil)
+        let request = Request(url: "http://example.com", headers: nil, queryParameters: nil)
         
         XCTAssertEqual(request.resourceUrl, "http://example.com")
         XCTAssertEqual(request.httpMethod.rawValue, "GET")
@@ -67,7 +67,7 @@ class BaseRequestTests: XCTestCase {
     
     func testSend() {
         
-        let request = BaseRequest(url: "http://example.com", headers: nil, queryParameters: ["someKey": "someValue"])
+        let request = Request(url: "http://example.com", headers: nil, queryParameters: ["someKey": "someValue"])
         
         let requestData = "{\"key1\": \"value1\", \"key2\": \"value2\"}".data(using: .utf8)
         
@@ -81,7 +81,7 @@ class BaseRequestTests: XCTestCase {
     
     func testSendWithoutOverwritingContentTypeHeader() {
         
-        let request = BaseRequest(url: "http://example.com", headers: [BaseRequest.contentType: "media-type"], queryParameters: ["someKey": "someValue"])
+        let request = Request(url: "http://example.com", headers: [Request.contentType: "media-type"], queryParameters: ["someKey": "someValue"])
         let dataString = "Some data text"
         
         let bodyData = "Some data text".data(using: .utf8)
@@ -91,7 +91,7 @@ class BaseRequestTests: XCTestCase {
         XCTAssertNil(request.headers["x-mfp-analytics-metadata"]) // This can only be set by the BMSAnalytics framework
         
         XCTAssertEqual(requestBodyAsString, dataString)
-        XCTAssertEqual(request.headers[BaseRequest.contentType], "media-type")
+        XCTAssertEqual(request.headers[Request.contentType], "media-type")
         XCTAssertEqual(request.resourceUrl, "http://example.com?someKey=someValue")
     }
     
@@ -100,7 +100,7 @@ class BaseRequestTests: XCTestCase {
         let responseReceivedExpectation = self.expectation(description: "Receive network response")
         
         let badUrl = "!@#$%^&*()"
-        let request = BaseRequest(url: badUrl, headers: nil, queryParameters: nil)
+        let request = Request(url: badUrl, headers: nil, queryParameters: nil)
         
         request.send { (response: Response?, error: Error?) -> Void in
             XCTAssertNil(response)
@@ -125,7 +125,7 @@ class BaseRequestTests: XCTestCase {
         let parameters: [String: String] = [:]
         
         let url = URL(string: "http://example.com")
-        let finalUrl = String( describing: BaseRequest.append(queryParameters: parameters, toURL: url!)! )
+        let finalUrl = String( describing: Request.append(queryParameters: parameters, toURL: url!)! )
         
         XCTAssertEqual(finalUrl, "http://example.com")
     }
@@ -136,7 +136,7 @@ class BaseRequestTests: XCTestCase {
         let parameters = ["key1": "value1", "key2": "value2"]
         
         let url = URL(string: "http://example.com")
-        let finalUrl = String( describing: BaseRequest.append(queryParameters: parameters, toURL: url!)! )
+        let finalUrl = String( describing: Request.append(queryParameters: parameters, toURL: url!)! )
         
         XCTAssertEqual(finalUrl, "http://example.com?key2=value2&key1=value1")
     }
@@ -146,7 +146,7 @@ class BaseRequestTests: XCTestCase {
         let parameters = ["Reserved_characters": "\"#%<>[\\]^`{|}"]
         
         let url = URL(string: "http://example.com")
-        let finalUrl = String( describing: BaseRequest.append(queryParameters: parameters, toURL: url!)! )
+        let finalUrl = String( describing: Request.append(queryParameters: parameters, toURL: url!)! )
         
         XCTAssert(finalUrl.contains("%22%23%25%3C%3E%5B%5C%5D%5E%60%7B%7C%7D"))
     }
@@ -156,7 +156,7 @@ class BaseRequestTests: XCTestCase {
         let parameters = ["key1": "value1", "key2": "value2"]
         
         let url = URL(string: "http://example.com?hardCodedKey=hardCodedValue")
-        let finalUrl = String( describing: BaseRequest.append(queryParameters: parameters, toURL: url!)! )
+        let finalUrl = String( describing: Request.append(queryParameters: parameters, toURL: url!)! )
         
         XCTAssertEqual(finalUrl, "http://example.com?hardCodedKey=hardCodedValue&key2=value2&key1=value1")
     }
@@ -166,7 +166,7 @@ class BaseRequestTests: XCTestCase {
         let parameters = ["k1": "v1", "k2": "v2", "k3": "v3", "k4": "v4"]
         
         let url = URL(string: "http://example.com")
-        let finalUrl = String( describing: BaseRequest.append(queryParameters: parameters, toURL: url!)! )
+        let finalUrl = String( describing: Request.append(queryParameters: parameters, toURL: url!)! )
         
         let numberOfAmpersands = finalUrl.components(separatedBy: "&")
         
@@ -191,19 +191,19 @@ class BaseRequestTests: XCTestCase {
     
     
 
-class BaseRequestTests: XCTestCase {
+class RequestTests: XCTestCase {
     
     
     // MARK: init
     
     func testInitWithAllParameters() {
         
-        let request = BaseRequest(url: "http://example.com", method: HttpMethod.GET, headers:[BaseRequest.contentType: "text/plain"], queryParameters: ["someKey": "someValue"], timeout: 10.0, autoRetries: 4)
+        let request = Request(url: "http://example.com", method: HttpMethod.GET, headers:[Request.contentType: "text/plain"], queryParameters: ["someKey": "someValue"], timeout: 10.0, autoRetries: 4)
         
         XCTAssertEqual(request.resourceUrl, "http://example.com")
         XCTAssertEqual(request.httpMethod.rawValue, "GET")
         XCTAssertEqual(request.timeout, 10.0)
-        XCTAssertEqual(request.headers, [BaseRequest.contentType: "text/plain"])
+        XCTAssertEqual(request.headers, [Request.contentType: "text/plain"])
         XCTAssertEqual(request.queryParameters!, ["someKey": "someValue"])
         XCTAssertEqual(request.urlSession.numberOfRetries, 4)
         XCTAssertNotNil(request.networkRequest)
@@ -213,14 +213,14 @@ class BaseRequestTests: XCTestCase {
         
         BMSClient.sharedInstance.initialize(bluemixAppRoute: "https://mybluemixapp.net", bluemixAppGUID: "1234", bluemixRegion: BMSClient.Region.usSouth)
         
-        let request = BaseRequest(url: "/path/to/resource", headers: nil, queryParameters: nil)
+        let request = Request(url: "/path/to/resource", headers: nil, queryParameters: nil)
         
         XCTAssertEqual(request.resourceUrl, "https://mybluemixapp.net/path/to/resource")
     }
     
     func testInitWithDefaultParameters() {
         
-        let request = BaseRequest(url: "http://example.com", headers: nil, queryParameters: nil)
+        let request = Request(url: "http://example.com", headers: nil, queryParameters: nil)
         
         XCTAssertEqual(request.resourceUrl, "http://example.com")
         XCTAssertEqual(request.httpMethod.rawValue, "GET")
@@ -236,7 +236,7 @@ class BaseRequestTests: XCTestCase {
     
     func testSend() {
         
-        let request = BaseRequest(url: "http://example.com", headers: nil, queryParameters: ["someKey": "someValue"])
+        let request = Request(url: "http://example.com", headers: nil, queryParameters: ["someKey": "someValue"])
         
         let requestData = "{\"key1\": \"value1\", \"key2\": \"value2\"}".dataUsingEncoding(NSUTF8StringEncoding)
         
@@ -251,7 +251,7 @@ class BaseRequestTests: XCTestCase {
     
     func testSendWithoutOverwritingContentTypeHeader() {
         
-        let request = BaseRequest(url: "http://example.com", headers: [BaseRequest.contentType: "media-type"], queryParameters: ["someKey": "someValue"])
+        let request = Request(url: "http://example.com", headers: [Request.contentType: "media-type"], queryParameters: ["someKey": "someValue"])
         let dataString = "Some data text"
         
         let bodyData = "Some data text".dataUsingEncoding(NSUTF8StringEncoding)
@@ -261,7 +261,7 @@ class BaseRequestTests: XCTestCase {
         XCTAssertNil(request.headers["x-mfp-analytics-metadata"]) // This can only be set by the BMSAnalytics framework
         
         XCTAssertEqual(requestBodyAsString, dataString)
-        XCTAssertEqual(request.headers[BaseRequest.contentType], "media-type")
+        XCTAssertEqual(request.headers[Request.contentType], "media-type")
         XCTAssertEqual(request.resourceUrl, "http://example.com?someKey=someValue")
     }
     
@@ -270,7 +270,7 @@ class BaseRequestTests: XCTestCase {
         let responseReceivedExpectation = self.expectationWithDescription("Receive network response")
         
         let badUrl = "!@#$%^&*()"
-        let request = BaseRequest(url: badUrl, headers: nil, queryParameters: nil)
+        let request = Request(url: badUrl, headers: nil, queryParameters: nil)
         
         request.send { (response: Response?, error: NSError?) -> Void in
             XCTAssertNil(response)
@@ -296,7 +296,7 @@ class BaseRequestTests: XCTestCase {
         let parameters: [String: String] = [:]
         
         let url = NSURL(string: "http://example.com")
-        let finalUrl = String( BaseRequest.append(queryParameters: parameters, toURL: url!)! )
+        let finalUrl = String( Request.append(queryParameters: parameters, toURL: url!)! )
     
         XCTAssertEqual(finalUrl, "http://example.com")
     }
@@ -307,7 +307,7 @@ class BaseRequestTests: XCTestCase {
         let parameters = ["key1": "value1", "key2": "value2"]
         
         let url = NSURL(string: "http://example.com")
-        let finalUrl = String( BaseRequest.append(queryParameters: parameters, toURL: url!)! )
+        let finalUrl = String( Request.append(queryParameters: parameters, toURL: url!)! )
         
         XCTAssertEqual(finalUrl, "http://example.com?key1=value1&key2=value2")
     }
@@ -317,7 +317,7 @@ class BaseRequestTests: XCTestCase {
         let parameters = ["Reserved_characters": "\"#%<>[\\]^`{|}"]
         
         let url = NSURL(string: "http://example.com")
-        let finalUrl = String( BaseRequest.append(queryParameters: parameters, toURL: url!)! )
+        let finalUrl = String( Request.append(queryParameters: parameters, toURL: url!)! )
         
         XCTAssert(finalUrl.containsString("%22%23%25%3C%3E%5B%5C%5D%5E%60%7B%7C%7D"))
     }
@@ -327,7 +327,7 @@ class BaseRequestTests: XCTestCase {
         let parameters = ["key1": "value1", "key2": "value2"]
         
         let url = NSURL(string: "http://example.com?hardCodedKey=hardCodedValue")
-        let finalUrl = String( BaseRequest.append(queryParameters: parameters, toURL: url!)! )
+        let finalUrl = String( Request.append(queryParameters: parameters, toURL: url!)! )
     
         XCTAssertEqual(finalUrl, "http://example.com?hardCodedKey=hardCodedValue&key1=value1&key2=value2")
     }
@@ -337,7 +337,7 @@ class BaseRequestTests: XCTestCase {
         let parameters = ["k1": "v1", "k2": "v2", "k3": "v3", "k4": "v4"]
         
         let url = NSURL(string: "http://example.com")
-        let finalUrl = String( BaseRequest.append(queryParameters: parameters, toURL: url!)! )
+        let finalUrl = String( Request.append(queryParameters: parameters, toURL: url!)! )
     
         let numberOfAmpersands = finalUrl.componentsSeparatedByString("&")
     


### PR DESCRIPTION
Since `BaseRequest` has been [deprecated](https://github.com/ibm-bluemix-mobile-services/bms-clientsdk-swift-core/commit/0a5282957ea4a427e3dd6ff3f67114848a2f055e), this pull request fixes a compiler warning by replacing an instance of `BaseRequest` with `Request`.

Note that the `open class Request: BaseRequest` declaration still produces a compiler warning. I assume this will be fixed in the next major version release.

Closes #17.