### PR TITLE
Update Cartfile.resolved

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "ibm-bluemix-mobile-services/bms-clientsdk-swift-analytics-api" "2.2.0"
+github "ibm-bluemix-mobile-services/bms-clientsdk-swift-analytics-api" "2.2.1"


### PR DESCRIPTION
Carthage resolved the analytics API to version 2.2.1 instead of 2.2.0. This pull request updates the `Carthage.resolved` file to reflect the new version when running `carthage bootstrap`.